### PR TITLE
Fixed typographical error, changed adminstration to administration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Rude keeps your git repositories _lean_ and focused on the code.
 ## Problem Statement
 
 Platform as a Service (PaaS) providers are increasingly popular nowadays.
-They let programmers focus on development, and leave systems adminstration to dedicated companies.
+They let programmers focus on development, and leave systems administration to dedicated companies.
 Deployment is typically triggered by pushing a Git repository to the service provider.
 
 Either you must choose to include your binary assets in your Git deployment,


### PR DESCRIPTION
@groundwater, I've corrected a typographical error in the documentation of the [rude](https://github.com/groundwater/rude) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.